### PR TITLE
Formatering + syntax fix

### DIFF
--- a/bin/dbwebb
+++ b/bin/dbwebb
@@ -300,7 +300,7 @@ publishResults()
     then
         $ECHO "Your files are now"
     else
-        $ECHO "Some of your files may might be"
+        $ECHO "Some of your files might be"
     fi
     $ECHO " published on $BASEURL"
     $ECHO "\n"


### PR DESCRIPTION
två spaces på ena sidan andra argumentet efter OR, och inget space efter (innan ]) gav felmeddelande, iaf i Dash. Varje expression ska tydligen vara inom egna brackets också, annars blev -o ledsen.

När jag skulle fixa det såg jag samtidigt att 'then' stod på ensam rad ibland, och inte ibland. En av dessa hade dessutom en massa trailing whitespace, så jag lagade även detta innan jag gjorde något annat.
