### PR TITLE
updated irc-from-dbwebb.py with archive url

### DIFF
--- a/example/scrape/irc-from-dbwebb.py
+++ b/example/scrape/irc-from-dbwebb.py
@@ -15,7 +15,7 @@ input("Press enter to continue. ")
 
 
 # Get webpage
-url = "http://dbwebb.se/"
+url = "http://cc1.dbwebb.se/"
 print("\nReady to send HTTP request to ", url, "\nPress enter to continue. ", end='')
 input()
 req = requests.get(url)


### PR DESCRIPTION
The new version of the website doesn't have the irc log, so the old scraper example won't work. A quick fix is to update the example with the archive url (cc1 subdomain), but I guess it would've been better to rewrite the example to use something from the new website. Or insert the irc log into the new website.